### PR TITLE
Move ads.txt to site root

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,6 @@ The site is organized for deployment on GitHub Pages and includes SEO files and 
 - `legal/terms.html` – terms and conditions
 - `legal/privacy.html` – privacy policy
 - `assets/` – CSS and JavaScript
-- `seo/` – `sitemap.xml`, `robots.txt`, and `ads.txt`
+- `seo/` – `sitemap.xml` and `robots.txt` (the `ads.txt` file lives in the site root)
 
 To view the site locally, open `index.html` in your browser.

--- a/ads.txt
+++ b/ads.txt
@@ -1,2 +1,1 @@
-# Google AdSense
 google.com, pub-6999979117716027, DIRECT, f08c47fec0942fa0

--- a/ads.txt
+++ b/ads.txt
@@ -1,0 +1,2 @@
+# Google AdSense
+google.com, pub-6999979117716027, DIRECT, f08c47fec0942fa0

--- a/seo/ads.txt
+++ b/seo/ads.txt
@@ -1,2 +1,0 @@
-# Placeholder for Google AdSense
-example.com, pub-0000000000000000, DIRECT, f08c47fec0942fa0


### PR DESCRIPTION
## Summary
- move `ads.txt` from `seo/` to repository root as required for Google AdSense
- update README to clarify ads file location

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6865cdf6069c8324898d55aa59f412a8