### PR TITLE
feat: add app-ads.txt for Google AdMob configuration

### DIFF
--- a/public/app-ads.txt
+++ b/public/app-ads.txt
@@ -1,0 +1,2 @@
+# Google AdMob
+google.com, pub-6999979117716027, DIRECT, f08c47fec0942fa0


### PR DESCRIPTION
This pull request adds a new entry for Google AdMob to the `public/app-ads.txt` file, specifying the authorized seller information for ad inventory. 

Ad platform configuration:

* Added a Google AdMob entry to `public/app-ads.txt` to authorize `pub-6999979117716027` as a direct seller.