### PR TITLE
Limpieza: eliminar banner central, ajustar texto 'Múltiples direcciones'

### DIFF
--- a/src/components/DualFeatureSection.astro
+++ b/src/components/DualFeatureSection.astro
@@ -35,7 +35,7 @@ import { BadgeDollarSign, Flame, LocateFixed, MapPinned, Navigation, Route, Truc
 				<div class="grid gap-5 p-8 md:grid-cols-3">
 					<div class="rounded-3xl bg-[var(--client-50)] p-5">
 						<MapPinned className="h-6 w-6 text-[var(--client-600)]" />
-						<h4 class="mt-4 text-lg font-semibold text-slate-950">Múltiples ubicaciones</h4>
+						<h4 class="mt-4 text-lg font-semibold text-slate-950">Múltiples direcciones</h4>
 						<p class="mt-2 text-sm leading-6 text-slate-600">Guarda casa, trabajo o puntos frecuentes y elige el destino correcto en segundos.</p>
 					</div>
 					<div class="rounded-3xl bg-[var(--client-50)] p-5">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -142,15 +142,7 @@ const adSlotIDBottom = '5427498442'
 			</div>
 		</section>
 
-		<section class="px-4 pb-12 sm:px-6 lg:px-8">
-			<div class="mx-auto flex max-w-6xl items-center justify-center gap-4 rounded-full border border-white/10 bg-white/70 px-6 py-4 shadow-lg shadow-slate-950/5 backdrop-blur">
-				<img src="/assets/img/icon.png" alt="Logo de Gasmovil" class="h-10 w-10 rounded-2xl object-cover" />
-				<div class="text-center">
-					<p class="text-xs font-semibold uppercase tracking-[0.35em] text-slate-400">Gasmovil</p>
-					<p class="text-sm text-slate-600">Tecnología para hacer más clara y rápida la entrega de gas LP.</p>
-				</div>
-			</div>
-		</section>
+
 
 		<section class="px-4 sm:px-6 lg:px-8">
 			<AdBanner


### PR DESCRIPTION
Cambios:\n- Eliminado el banner promocional 'Tecnología para hacer más clara y rápida...' que parecía footer en medio de la página\n- 'Múltiples ubicaciones' → 'Múltiples direcciones' en card Modo Cliente